### PR TITLE
Allow user to mark visual summary as read or favorite and persisting the state on local DB

### DIFF
--- a/lib/models/visual_summary.dart
+++ b/lib/models/visual_summary.dart
@@ -29,6 +29,8 @@ class VisualSummary {
   String? linkVisualInfographicSource;
   String? linkVisualInfographicThumbnailStorage;
   String? linkVisualInfographicThumbnailSource;
+  late bool readStatus = false;
+  late bool starStatus = false;
 }
 
 /// FNV-1a 64bit hash algorithm optimized for Dart Strings

--- a/lib/models/visual_summary.g.dart
+++ b/lib/models/visual_summary.g.dart
@@ -122,18 +122,28 @@ const VisualSummarySchema = CollectionSchema(
       name: r'organSystems',
       type: IsarType.stringList,
     ),
-    r'recordedPodcastTitle': PropertySchema(
+    r'readStatus': PropertySchema(
       id: 21,
+      name: r'readStatus',
+      type: IsarType.bool,
+    ),
+    r'recordedPodcastTitle': PropertySchema(
+      id: 22,
       name: r'recordedPodcastTitle',
       type: IsarType.string,
     ),
+    r'starStatus': PropertySchema(
+      id: 23,
+      name: r'starStatus',
+      type: IsarType.bool,
+    ),
     r'title': PropertySchema(
-      id: 22,
+      id: 24,
       name: r'title',
       type: IsarType.string,
     ),
     r'yearGuidelinePublished': PropertySchema(
-      id: 23,
+      id: 25,
       name: r'yearGuidelinePublished',
       type: IsarType.long,
     )
@@ -309,9 +319,11 @@ void _visualSummarySerialize(
   writer.writeString(offsets[18], object.mimeTypeVisualSummary);
   writer.writeString(offsets[19], object.mimeTypeVisualSummaryThumbnail);
   writer.writeStringList(offsets[20], object.organSystems);
-  writer.writeString(offsets[21], object.recordedPodcastTitle);
-  writer.writeString(offsets[22], object.title);
-  writer.writeLong(offsets[23], object.yearGuidelinePublished);
+  writer.writeBool(offsets[21], object.readStatus);
+  writer.writeString(offsets[22], object.recordedPodcastTitle);
+  writer.writeBool(offsets[23], object.starStatus);
+  writer.writeString(offsets[24], object.title);
+  writer.writeLong(offsets[25], object.yearGuidelinePublished);
 }
 
 VisualSummary _visualSummaryDeserialize(
@@ -347,9 +359,11 @@ VisualSummary _visualSummaryDeserialize(
   object.mimeTypeVisualSummary = reader.readStringOrNull(offsets[18]);
   object.mimeTypeVisualSummaryThumbnail = reader.readStringOrNull(offsets[19]);
   object.organSystems = reader.readStringList(offsets[20]) ?? [];
-  object.recordedPodcastTitle = reader.readStringOrNull(offsets[21]);
-  object.title = reader.readString(offsets[22]);
-  object.yearGuidelinePublished = reader.readLong(offsets[23]);
+  object.readStatus = reader.readBool(offsets[21]);
+  object.recordedPodcastTitle = reader.readStringOrNull(offsets[22]);
+  object.starStatus = reader.readBool(offsets[23]);
+  object.title = reader.readString(offsets[24]);
+  object.yearGuidelinePublished = reader.readLong(offsets[25]);
   return object;
 }
 
@@ -403,10 +417,14 @@ P _visualSummaryDeserializeProp<P>(
     case 20:
       return (reader.readStringList(offset) ?? []) as P;
     case 21:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBool(offset)) as P;
     case 22:
-      return (reader.readString(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 23:
+      return (reader.readBool(offset)) as P;
+    case 24:
+      return (reader.readString(offset)) as P;
+    case 25:
       return (reader.readLong(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -3973,6 +3991,16 @@ extension VisualSummaryQueryFilter
   }
 
   QueryBuilder<VisualSummary, VisualSummary, QAfterFilterCondition>
+      readStatusEqualTo(bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'readStatus',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<VisualSummary, VisualSummary, QAfterFilterCondition>
       recordedPodcastTitleIsNull() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(const FilterCondition.isNull(
@@ -4122,6 +4150,16 @@ extension VisualSummaryQueryFilter
       return query.addFilterCondition(FilterCondition.greaterThan(
         property: r'recordedPodcastTitle',
         value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<VisualSummary, VisualSummary, QAfterFilterCondition>
+      starStatusEqualTo(bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'starStatus',
+        value: value,
       ));
     });
   }
@@ -4565,6 +4603,19 @@ extension VisualSummaryQuerySortBy
     });
   }
 
+  QueryBuilder<VisualSummary, VisualSummary, QAfterSortBy> sortByReadStatus() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'readStatus', Sort.asc);
+    });
+  }
+
+  QueryBuilder<VisualSummary, VisualSummary, QAfterSortBy>
+      sortByReadStatusDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'readStatus', Sort.desc);
+    });
+  }
+
   QueryBuilder<VisualSummary, VisualSummary, QAfterSortBy>
       sortByRecordedPodcastTitle() {
     return QueryBuilder.apply(this, (query) {
@@ -4576,6 +4627,19 @@ extension VisualSummaryQuerySortBy
       sortByRecordedPodcastTitleDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'recordedPodcastTitle', Sort.desc);
+    });
+  }
+
+  QueryBuilder<VisualSummary, VisualSummary, QAfterSortBy> sortByStarStatus() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'starStatus', Sort.asc);
+    });
+  }
+
+  QueryBuilder<VisualSummary, VisualSummary, QAfterSortBy>
+      sortByStarStatusDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'starStatus', Sort.desc);
     });
   }
 
@@ -4858,6 +4922,19 @@ extension VisualSummaryQuerySortThenBy
     });
   }
 
+  QueryBuilder<VisualSummary, VisualSummary, QAfterSortBy> thenByReadStatus() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'readStatus', Sort.asc);
+    });
+  }
+
+  QueryBuilder<VisualSummary, VisualSummary, QAfterSortBy>
+      thenByReadStatusDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'readStatus', Sort.desc);
+    });
+  }
+
   QueryBuilder<VisualSummary, VisualSummary, QAfterSortBy>
       thenByRecordedPodcastTitle() {
     return QueryBuilder.apply(this, (query) {
@@ -4869,6 +4946,19 @@ extension VisualSummaryQuerySortThenBy
       thenByRecordedPodcastTitleDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'recordedPodcastTitle', Sort.desc);
+    });
+  }
+
+  QueryBuilder<VisualSummary, VisualSummary, QAfterSortBy> thenByStarStatus() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'starStatus', Sort.asc);
+    });
+  }
+
+  QueryBuilder<VisualSummary, VisualSummary, QAfterSortBy>
+      thenByStarStatusDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'starStatus', Sort.desc);
     });
   }
 
@@ -5063,11 +5153,23 @@ extension VisualSummaryQueryWhereDistinct
     });
   }
 
+  QueryBuilder<VisualSummary, VisualSummary, QDistinct> distinctByReadStatus() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'readStatus');
+    });
+  }
+
   QueryBuilder<VisualSummary, VisualSummary, QDistinct>
       distinctByRecordedPodcastTitle({bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'recordedPodcastTitle',
           caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<VisualSummary, VisualSummary, QDistinct> distinctByStarStatus() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'starStatus');
     });
   }
 
@@ -5238,10 +5340,22 @@ extension VisualSummaryQueryProperty
     });
   }
 
+  QueryBuilder<VisualSummary, bool, QQueryOperations> readStatusProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'readStatus');
+    });
+  }
+
   QueryBuilder<VisualSummary, String?, QQueryOperations>
       recordedPodcastTitleProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'recordedPodcastTitle');
+    });
+  }
+
+  QueryBuilder<VisualSummary, bool, QQueryOperations> starStatusProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'starStatus');
     });
   }
 

--- a/lib/visual_summary/visual_summary_detail_page.dart
+++ b/lib/visual_summary/visual_summary_detail_page.dart
@@ -112,7 +112,7 @@ class _VisualSummaryDetailPageState extends State<VisualSummaryDetailPage> {
                             IsarService().saveVisualSummary(widget.visualSummary);
                           },
                           icon: Icon(
-                            CupertinoIcons.check_mark_circled,
+                            CupertinoIcons.eye,
                             color: widget.visualSummary.readStatus ? Colors.green : Colors.black,
                             size: iconSize,
                             semanticLabel: 'Text to announce in accessibility modes',
@@ -132,8 +132,8 @@ class _VisualSummaryDetailPageState extends State<VisualSummaryDetailPage> {
                             IsarService().saveVisualSummary(widget.visualSummary);
                           },
                           icon: Icon(
-                            CupertinoIcons.star,
-                            color: widget.visualSummary.starStatus ? Colors.green : Colors.black,
+                            widget.visualSummary.starStatus ? CupertinoIcons.star_fill : CupertinoIcons.star,
+                            color: widget.visualSummary.starStatus ? Colors.yellow : Colors.black,
                             size: iconSize,
                             semanticLabel: 'Text to announce in accessibility modes',
                           ),

--- a/lib/visual_summary/visual_summary_detail_page.dart
+++ b/lib/visual_summary/visual_summary_detail_page.dart
@@ -5,6 +5,8 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../models/visual_summary.dart';
 
+import '../isar_service.dart';
+
 class VisualSummaryDetailPage extends StatefulWidget {
   const VisualSummaryDetailPage({super.key, required this.visualSummary, required this.setVisualSummarySelected});
 
@@ -92,6 +94,46 @@ class _VisualSummaryDetailPageState extends State<VisualSummaryDetailPage> {
                           icon: Icon(
                             CupertinoIcons.heart,
                             color: Colors.black,
+                            size: iconSize,
+                            semanticLabel: 'Text to announce in accessibility modes',
+                          ),
+                          iconSize: iconSize,
+                        ),
+                        const SizedBox(width: 10),
+                        IconButton(
+                          onPressed: () {
+                            setState(() {
+                              if (widget.visualSummary.readStatus) {
+                                widget.visualSummary.readStatus = false;
+                              } else {
+                                widget.visualSummary.readStatus = true;
+                              }
+                            });
+                            IsarService().saveVisualSummary(widget.visualSummary);
+                          },
+                          icon: Icon(
+                            CupertinoIcons.check_mark_circled,
+                            color: widget.visualSummary.readStatus ? Colors.green : Colors.black,
+                            size: iconSize,
+                            semanticLabel: 'Text to announce in accessibility modes',
+                          ),
+                          iconSize: iconSize,
+                        ),
+                        const SizedBox(width: 10),
+                        IconButton(
+                          onPressed: () {
+                            setState(() {
+                              if (widget.visualSummary.starStatus) {
+                                widget.visualSummary.starStatus = false;
+                              } else {
+                                widget.visualSummary.starStatus = true;
+                              }
+                            });
+                            IsarService().saveVisualSummary(widget.visualSummary);
+                          },
+                          icon: Icon(
+                            CupertinoIcons.star,
+                            color: widget.visualSummary.starStatus ? Colors.green : Colors.black,
                             size: iconSize,
                             semanticLabel: 'Text to announce in accessibility modes',
                           ),


### PR DESCRIPTION
On visual summary detail page, add a icon for user to mark visual summary as read/unread. Add a star icon to mark the visual summary as favorite.

Task: https://jid-2352-the-emoroid-digest-app.atlassian.net/browse/J2EDA-45