### PR TITLE
Fix icon size to prevent overflow

### DIFF
--- a/lib/pages/podcast/podcast_detail_page.dart
+++ b/lib/pages/podcast/podcast_detail_page.dart
@@ -31,7 +31,7 @@ class PodcastDetailPage extends StatefulWidget {
 }
 
 class _PodcastDetailPageState extends State<PodcastDetailPage> with LocalFileSystem {
-  final double iconSize = 30;
+  final double iconSize = 25;
   final double fieldFontSize = 16;
   PageManager? _pageManager;
   late AudioHandler _audioHandler;
@@ -375,7 +375,7 @@ class _PodcastDetailPageState extends State<PodcastDetailPage> with LocalFileSys
                       onPressed: setNewAudio,
                     ),
                   Padding(
-                    padding: const EdgeInsets.only(left: 8, right: 8),
+                    padding: const EdgeInsets.only(left: 4, right: 4),
                     child: Column(
                       children: [
                         Row(
@@ -394,7 +394,7 @@ class _PodcastDetailPageState extends State<PodcastDetailPage> with LocalFileSys
                                 semanticLabel: 'An eye icon to indicate if a user has listened a podcast',
                               ),
                             ),
-                            const SizedBox(width: 10),
+                            const SizedBox(width: 8),
                             IconButton(
                               onPressed: () {
                                 setState(() {
@@ -410,7 +410,7 @@ class _PodcastDetailPageState extends State<PodcastDetailPage> with LocalFileSys
                                     'A heart icon to indicate if a user has marked a podcast as favorite',
                               ),
                             ),
-                            const SizedBox(width: 10),
+                            const SizedBox(width: 8),
                             IconButton(
                               onPressed: () {
                                 Share.share('Check out this Podcast emoroiddigestapp://host/podcast/detail?id=${args.podcastID}');
@@ -418,7 +418,7 @@ class _PodcastDetailPageState extends State<PodcastDetailPage> with LocalFileSys
                               icon: const Icon(Icons.share_outlined),
                               iconSize: iconSize,
                             ),
-                            const SizedBox(width: 10),
+                            const SizedBox(width: 8),
                             if (podcast.twitterPodcastLink != null)
                               IconButton(
                                 //Button to jump to twitter for discussion

--- a/lib/pages/visual_summary/visual_summary_detail_page.dart
+++ b/lib/pages/visual_summary/visual_summary_detail_page.dart
@@ -250,7 +250,7 @@ class _VisualSummaryDetailPageState extends State<VisualSummaryDetailPage> with 
                         }
                       }),
                   Padding(
-                    padding: const EdgeInsets.only(left: 8, right: 8),
+                    padding: const EdgeInsets.only(left: 4, right: 4),
                     child: Column(
                       children: [
                         Row(
@@ -269,7 +269,7 @@ class _VisualSummaryDetailPageState extends State<VisualSummaryDetailPage> with 
                                 semanticLabel: 'An eye icon to indicate if a user has read a visual summary',
                               ),
                             ),
-                            const SizedBox(width: 10),
+                            const SizedBox(width: 8),
                             IconButton(
                               onPressed: () {
                                 if (!visualSummary.isFavorite) {
@@ -292,7 +292,7 @@ class _VisualSummaryDetailPageState extends State<VisualSummaryDetailPage> with 
                                     'A heart icon to indicate if a user has marked a visual summary as favorite',
                               ),
                             ),
-                            SizedBox(width: _isLoading ? 21.5 : 10),
+                            SizedBox(width: _isLoading ? 21.5 : 8),
                             if (_isLoading == true)
                               const SizedBox(
                                 height: 25.0,
@@ -315,7 +315,7 @@ class _VisualSummaryDetailPageState extends State<VisualSummaryDetailPage> with 
                                 icon: const Icon(Icons.delete),
                                 iconSize: iconSize,
                               ),
-                            SizedBox(width: _isLoading ? 21.5 : 10),
+                            SizedBox(width: _isLoading ? 21.5 : 8),
                             IconButton(
                               onPressed: () async {
                                 final uri = Uri.parse(visualSummary.linkOriginalManuscript);
@@ -336,7 +336,7 @@ class _VisualSummaryDetailPageState extends State<VisualSummaryDetailPage> with 
                               icon: const Icon(Icons.description_outlined),
                               iconSize: iconSize,
                             ),
-                            const SizedBox(width: 10),
+                            const SizedBox(width: 8),
                             IconButton(
                               onPressed: () {
                                 Share.share('Check out this Visual Summary emoroiddigestapp://host/visualSummary/detail?id=${args.visualSummaryID}');
@@ -344,7 +344,7 @@ class _VisualSummaryDetailPageState extends State<VisualSummaryDetailPage> with 
                               icon: const Icon(Icons.share_outlined),
                               iconSize: iconSize,
                             ),
-                            const SizedBox(width: 10),
+                            const SizedBox(width: 8),
                             if (visualSummary.linkTwitter != null)
                               IconButton(
                                 //Button to jump to twitter for discussion


### PR DESCRIPTION
I have tested all screens (visual summaries, home page, podcasts) for different screen size 

- iPad
- iPad Mini
- iPad Air
- iPad Pro
- iPhone SE
- Nexus 9 (Android Tablet)
- Pixel 6 (Android Phone)

and they are all working as intended.